### PR TITLE
adds a kustomization file

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -85,3 +85,14 @@ jobs:
 
       - name: Check changelog format
         run: make test-changelog
+
+  kustomize:
+    name: Kustomize
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Test rendering manifests using kustomize
+        run: make build-kustomize

--- a/Makefile
+++ b/Makefile
@@ -121,6 +121,10 @@ test-changelog: check-working-tree-clean ## Verifies that changelog is properly 
 	make format-changelog
 	@test -z "$$(git status --porcelain)" || (echo "Please run 'make format-changelog' and commit generated changes."; git diff; exit 1)
 
+.PHONY: build-kustomize
+build-kustomize: ## Renders manifests using kustomize.
+	kustomize build examples/deploy/
+
 .PHONY: help
 help: ## Prints help message.
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/examples/deploy/kustomization.yaml
+++ b/examples/deploy/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ./rbac/
+- 00-namespace.yaml
+- podsecuritypolicy.yaml
+- update-agent-sa.yaml
+- update-agent.yaml
+- update-operator-sa.yaml
+- update-operator.yaml

--- a/examples/deploy/rbac/kustomization.yaml
+++ b/examples/deploy/rbac/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- cluster-role.yaml
+- cluster-role-binding.yaml


### PR DESCRIPTION
# adds a kustomization file

currently this adds a kustomization file that makes it easier to apply yaml changes

## How to use

`kustomize build .`

or create a patch inside another directory:

```
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization

resources:
- path/to/folder/of/reboot-coordinator/kustomization/file
namespace: reboot-coordinator
patches:
- path: custom-env.yaml
  target:
    group: apps
    version: v1
    kind: Deployment
    name: flatcar-linux-update-operator
```

custom-env.yaml:
```
kind: Deployment
metadata:
  name: flatcar-linux-update-operator
  namespace: reboot-coordinator
spec:
  template:
    spec:
      containers:
        - name: update-operator
          env:
          - name: UPDATE_OPERATOR_REBOOT_WINDOW_START
            value: "Sun 01:00"
          - name: UPDATE_OPERATOR_REBOOT_WINDOW_LENGTH
            value: "2h
```

## Testing done

checked the output of `kustomize build .` so that it also applies the reboot window
