### PR TITLE
Fixes #121 - flatcar-linux-update-agent daemonset referencing the wrong serv…

### DIFF
--- a/examples/deploy/podsecuritypolicy.yaml
+++ b/examples/deploy/podsecuritypolicy.yaml
@@ -64,11 +64,11 @@ spec:
   supplementalGroups:
     rule: 'MustRunAs'
     ranges:
-      - min: 1
+      - min: 0
         max: 65535
   fsGroup:
     rule: 'MustRunAs'
     ranges:
-      - min: 1
+      - min: 0
         max: 65535
   readOnlyRootFilesystem: true

--- a/examples/deploy/podsecuritypolicy.yaml
+++ b/examples/deploy/podsecuritypolicy.yaml
@@ -64,11 +64,11 @@ spec:
   supplementalGroups:
     rule: 'MustRunAs'
     ranges:
-      - min: 0
+      - min: 1
         max: 65535
   fsGroup:
     rule: 'MustRunAs'
     ranges:
-      - min: 0
+      - min: 1
         max: 65535
   readOnlyRootFilesystem: true

--- a/examples/deploy/update-agent.yaml
+++ b/examples/deploy/update-agent.yaml
@@ -16,7 +16,7 @@ spec:
       labels:
         app: flatcar-linux-update-agent
     spec:
-      serviceAccountName: flatcar-linux-update-operator-sa
+      serviceAccountName: flatcar-linux-update-agent
       containers:
       - name: update-agent
         image: ghcr.io/flatcar-linux/flatcar-linux-update-operator:v0.8.0


### PR DESCRIPTION
# [Fixes flatcar-linux-update-agent daemonset referencing the wrong serviceaccount]

[ Fixing the incorrect reference of the ServiceAccount and runAs range specified in the posdsecuritypolicy ]

## How to use

[ Just apply the resources ]

## Testing done

[ I ran it and now the update-agent daemonset was allowed to run]

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)

Closes #121