### PR TITLE
pkg/operator: add tests for failing code branches

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -48,6 +48,10 @@ issues:
     - linters:
         - wrapcheck
       text: "error returned from interface method should be wrapped"
+    # False positive: https://github.com/kunwardeep/paralleltest/issues/8.
+    - linters:
+        - paralleltest
+      text: "does not use range value in test Run"
 
 linters-settings:
   errcheck:

--- a/pkg/agent/agent_internal_test.go
+++ b/pkg/agent/agent_internal_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-func Test_slitNewlineEnv(t *testing.T) {
+func Test_splitNewlineEnv(t *testing.T) {
 	t.Parallel()
 
 	t.Run("retain_map_values_when_given_empty_input", func(t *testing.T) {


### PR DESCRIPTION
Those tests are rather fragile, but they bring test coverage to 100% so
lets have them around until operator code is refactored, so they won't
be needed.

Signed-off-by: Mateusz Gozdek <mgozdek@microsoft.com>

Part of #60.