### PR TITLE
examples/deploy/rbac/cluster-role.yaml: remove namespace

### DIFF
--- a/examples/deploy/rbac/cluster-role.yaml
+++ b/examples/deploy/rbac/cluster-role.yaml
@@ -2,7 +2,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: flatcar-linux-update-operator
-  namespace: reboot-coordinator
 rules:
   - apiGroups:
       - ""
@@ -57,7 +56,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: flatcar-linux-update-agent
-  namespace: reboot-coordinator
 rules:
   - apiGroups:
       - ""


### PR DESCRIPTION
ClusterRole resources are cluster-scoped, not namespace-scoped so
namespace field on them is no-op. It should be removed then to avoid
clutter.

Signed-off-by: Mateusz Gozdek <mgozdek@microsoft.com>