### PR TITLE
Compatibility with Kubernetes 1.24

### DIFF
--- a/pkg/operator/operator_test.go
+++ b/pkg/operator/operator_test.go
@@ -91,6 +91,15 @@ func Test_Creating_new_operator(t *testing.T) {
 			}
 		})
 
+		t.Run("lockType_is_incorrect", func(t *testing.T) {
+			config := validOperatorConfig()
+			config.LockType = "incorrect"
+
+			if _, err := operator.New(config); err == nil {
+				t.Fatalf("Expected error")
+			}
+		})
+
 		t.Run("invalid_reboot_window_is_configured", func(t *testing.T) {
 			t.Parallel()
 


### PR DESCRIPTION
# Compatibility with Kubernetes 1.24

The **ConfigMapLock** resource is deprecated and was removed from the latest version of Kubernetes (1.24)

As you can see in the code, they recommend using ConfigMapsLeasesResourceLock instead
https://github.com/kubernetes/client-go/blob/v0.24.1/tools/leaderelection/resourcelock/interface.go#L194-L195

```
case configMapsResourceLock:
	return nil, fmt.Errorf("configmaps lock is removed, migrate to %s", ConfigMapsLeasesResourceLock)
```
